### PR TITLE
Fix/consent definition overlap

### DIFF
--- a/consent_app/baker_recipes.py
+++ b/consent_app/baker_recipes.py
@@ -5,7 +5,13 @@ from edc_utils import get_utcnow
 from faker import Faker
 from model_bakery.recipe import Recipe, seq
 
-from .models import SubjectConsent, SubjectConsentV1, SubjectConsentV2, SubjectConsentV3
+from .models import (
+    SubjectConsent,
+    SubjectConsentV1,
+    SubjectConsentV2,
+    SubjectConsentV3,
+    SubjectConsentV4,
+)
 
 fake = Faker()
 
@@ -42,3 +48,4 @@ subjectconsent = Recipe(SubjectConsent, **get_opts())
 subjectconsentv1 = Recipe(SubjectConsentV1, **get_opts())
 subjectconsentv2 = Recipe(SubjectConsentV2, **get_opts())
 subjectconsentv3 = Recipe(SubjectConsentV3, **get_opts())
+subjectconsentv4 = Recipe(SubjectConsentV4, **get_opts())

--- a/consent_app/models.py
+++ b/consent_app/models.py
@@ -87,7 +87,6 @@ class SubjectConsentUgV1(SubjectConsent):
 
 
 class SubjectConsentV2(SubjectConsent):
-
     on_site = CurrentSiteByCdefManager()
     objects = ConsentObjectsByCdefManager()
 
@@ -96,6 +95,14 @@ class SubjectConsentV2(SubjectConsent):
 
 
 class SubjectConsentV3(SubjectConsent):
+    on_site = CurrentSiteByCdefManager()
+    objects = ConsentObjectsByCdefManager()
+
+    class Meta:
+        proxy = True
+
+
+class SubjectConsentV4(SubjectConsent):
     on_site = CurrentSiteByCdefManager()
     objects = ConsentObjectsByCdefManager()
 

--- a/edc_consent/consent_definition.py
+++ b/edc_consent/consent_definition.py
@@ -11,7 +11,7 @@ from edc_protocol.research_protocol_config import ResearchProtocolConfig
 from edc_screening.utils import get_subject_screening_model
 from edc_sites import site_sites
 from edc_utils import floor_secs, formatted_date, formatted_datetime
-from edc_utils.date import ceil_datetime, floor_datetime, to_local, to_utc
+from edc_utils.date import ceil_datetime, floor_datetime, to_local
 
 from .exceptions import (
     ConsentDefinitionError,
@@ -120,42 +120,23 @@ class ConsentDefinition:
     def get_consent_for(
         self,
         subject_identifier: str = None,
-        report_datetime: datetime | None = None,
+        site_id: int | None = None,
         raise_if_not_consented: bool | None = None,
     ) -> ConsentLikeModel | None:
-        """Returns a subject consent using this consent_definition's
-        `model_cls` and `version`.
-
-        If it does not exist and this consent_definition updates a
-        previous (`update_cdef`), will try again with the `update_cdef's`
-        model_cls and version.
-
-        Finally, if the subject consent does not exist raises a
-        `NotConsentedError`.
-        """
-        consent_obj = None
         raise_if_not_consented = (
             True if raise_if_not_consented is None else raise_if_not_consented
         )
-        opts: dict[str, str | datetime] = dict(
-            subject_identifier=subject_identifier, version=self.version
-        )
-        if report_datetime:
-            opts.update(consent_datetime__lte=to_utc(report_datetime))
+        opts = dict(subject_identifier=subject_identifier, version=self.version)
+        if site_id:
+            opts.update(site_id=site_id)
         try:
             consent_obj = self.model_cls.objects.get(**opts)
         except ObjectDoesNotExist:
-            if self.updates:
-                opts.update(version=self.updates.version)
-                try:
-                    consent_obj = self.updates.model_cls.objects.get(**opts)
-                except ObjectDoesNotExist:
-                    pass
+            consent_obj = None
         if not consent_obj and raise_if_not_consented:
-            dte = formatted_date(report_datetime)
             raise NotConsentedError(
-                f"Consent not found. Has subject '{subject_identifier}' "
-                f"completed version '{self.version}' of consent on or after '{dte}'?"
+                f"Consent not found for this version. Has subject '{subject_identifier}' "
+                f"completed a version '{self.version}' consent?"
             )
         return consent_obj
 

--- a/edc_consent/consent_definition.py
+++ b/edc_consent/consent_definition.py
@@ -124,14 +124,14 @@ class ConsentDefinition:
         raise_if_not_consented: bool | None = None,
     ) -> ConsentLikeModel | None:
         """Returns a subject consent using this consent_definition's
-        model_cls and version.
+        `model_cls` and `version`.
 
         If it does not exist and this consent_definition updates a
-        previous (update_cdef), will try again with the update_cdef's
+        previous (`update_cdef`), will try again with the `update_cdef's`
         model_cls and version.
 
-        Finally, if the subject cosent does not exist raises a
-        NotConsentedError.
+        Finally, if the subject consent does not exist raises a
+        `NotConsentedError`.
         """
         consent_obj = None
         raise_if_not_consented = (

--- a/edc_consent/exceptions.py
+++ b/edc_consent/exceptions.py
@@ -32,3 +32,7 @@ class AlreadyRegistered(Exception):
 
 class SiteConsentError(Exception):
     pass
+
+
+class ConsentDefinitionNotConfiguredForUpdate(Exception):
+    pass

--- a/edc_consent/form_validators/consent_definition_form_validator_mixin.py
+++ b/edc_consent/form_validators/consent_definition_form_validator_mixin.py
@@ -8,7 +8,11 @@ from edc_sites.site import sites as site_sites
 
 from edc_consent import ConsentDefinitionDoesNotExist, site_consents
 from edc_consent.consent_definition import ConsentDefinition
-from edc_consent.exceptions import NotConsentedError, SiteConsentError
+from edc_consent.exceptions import (
+    ConsentDefinitionNotConfiguredForUpdate,
+    NotConsentedError,
+    SiteConsentError,
+)
 
 
 class ConsentDefinitionFormValidatorMixin:
@@ -38,18 +42,14 @@ class ConsentDefinitionFormValidatorMixin:
         Wraps func `consent_datetime_or_raise` to re-raise exceptions
         as ValidationError.
         """
+
         fldname = fldname or "report_datetime"
         error_code = error_code or INVALID_ERROR
-        consent_definition = self.get_consent_definition(
-            report_datetime=report_datetime, fldname=fldname, error_code=error_code
-        )
-        # use the consent_definition to get the subject consent model instance
         try:
-            consent_obj = consent_definition.get_consent_for(
-                subject_identifier=self.subject_identifier,
-                report_datetime=report_datetime,
+            consent_obj = site_consents.get_consent_or_raise(
+                subject_identifier=self.subject_consent, report_datetime=report_datetime
             )
-        except NotConsentedError as e:
+        except (NotConsentedError, ConsentDefinitionNotConfiguredForUpdate) as e:
             self.raise_validation_error({fldname: str(e)}, error_code)
         return consent_obj
 

--- a/edc_consent/managers.py
+++ b/edc_consent/managers.py
@@ -24,16 +24,7 @@ class ConsentObjectsByCdefManager(ConsentObjectsManager):
     def get_queryset(self):
         qs = super().get_queryset()
         cdef = site_consents.get_consent_definition(model=qs.model._meta.label_lower)
-        # return qs.filter(
-        #     version=cdef.version,
-        #     consent_datetime__gte=cdef.start,
-        #     consent_datetime__lte=cdef.end,
-        # )
-        return qs.filter(
-            version=cdef.version,
-            consent_datetime__gte=cdef.start,
-            consent_datetime__lte=cdef.end,
-        ).exclude(consent_datetime__lt=cdef.start, consent_datetime__gt=cdef.end)
+        return qs.filter(version=cdef.version)
 
 
 class CurrentSiteByCdefManager(CurrentSiteManager):
@@ -46,14 +37,4 @@ class CurrentSiteByCdefManager(CurrentSiteManager):
     def get_queryset(self):
         qs = super().get_queryset()
         cdef = site_consents.get_consent_definition(model=qs.model._meta.label_lower)
-        # return qs.filter(
-        #     version=cdef.version,
-        #     consent_datetime__gte=cdef.start,
-        #     consent_datetime__lte=cdef.end,
-        # )
-        return qs.filter(
-            site_id=cdef.site.site_id,
-            version=cdef.version,
-            consent_datetime__gte=cdef.start,
-            consent_datetime__lte=cdef.end,
-        ).exclude(consent_datetime__lt=cdef.start, consent_datetime__gt=cdef.end)
+        return qs.filter(site_id=cdef.site.site_id, version=cdef.version)

--- a/edc_consent/managers.py
+++ b/edc_consent/managers.py
@@ -24,7 +24,16 @@ class ConsentObjectsByCdefManager(ConsentObjectsManager):
     def get_queryset(self):
         qs = super().get_queryset()
         cdef = site_consents.get_consent_definition(model=qs.model._meta.label_lower)
-        return qs.filter(version=cdef.version)
+        # return qs.filter(
+        #     version=cdef.version,
+        #     consent_datetime__gte=cdef.start,
+        #     consent_datetime__lte=cdef.end,
+        # )
+        return qs.filter(
+            version=cdef.version,
+            consent_datetime__gte=cdef.start,
+            consent_datetime__lte=cdef.end,
+        ).exclude(consent_datetime__lt=cdef.start, consent_datetime__gt=cdef.end)
 
 
 class CurrentSiteByCdefManager(CurrentSiteManager):
@@ -37,4 +46,14 @@ class CurrentSiteByCdefManager(CurrentSiteManager):
     def get_queryset(self):
         qs = super().get_queryset()
         cdef = site_consents.get_consent_definition(model=qs.model._meta.label_lower)
-        return qs.filter(version=cdef.version)
+        # return qs.filter(
+        #     version=cdef.version,
+        #     consent_datetime__gte=cdef.start,
+        #     consent_datetime__lte=cdef.end,
+        # )
+        return qs.filter(
+            site_id=cdef.site.site_id,
+            version=cdef.version,
+            consent_datetime__gte=cdef.start,
+            consent_datetime__lte=cdef.end,
+        ).exclude(consent_datetime__lt=cdef.start, consent_datetime__gt=cdef.end)

--- a/edc_consent/models/signals.py
+++ b/edc_consent/models/signals.py
@@ -29,9 +29,10 @@ def requires_consent_on_pre_save(instance, raw, using, update_fields, **kwargs):
             consent_definition = site_consents.get_consent_definition(
                 site=site_sites.get(site.id), report_datetime=instance.report_datetime
             )
-        consent_definition.get_consent_for(
+        site_consents.get_consent_or_raise(
             subject_identifier=subject_identifier,
             report_datetime=instance.report_datetime,
+            site_id=site.id,
         )
         instance.consent_version = consent_definition.version
         instance.consent_model = consent_definition.model

--- a/edc_consent/site_consents.py
+++ b/edc_consent/site_consents.py
@@ -99,6 +99,15 @@ class SiteConsents:
                         f"Got {cdef.name}."
                     )
 
+    def get_consent_for(
+        self, subject_identifier: str, report_datetime: datetime, site_id: int
+    ):
+        from edc_sites.site import sites as site_sites  # avoid circular import
+
+        single_site = site_sites.get(site_id)
+        cdef = self.get_consent_definition(report_datetime=report_datetime, site=single_site)
+        return cdef.get_consent_for(subject_identifier)
+
     def get_consent_definition(
         self,
         model: str = None,

--- a/edc_consent/site_consents.py
+++ b/edc_consent/site_consents.py
@@ -15,6 +15,7 @@ from .exceptions import (
     AlreadyRegistered,
     ConsentDefinitionDoesNotExist,
     ConsentDefinitionError,
+    ConsentDefinitionNotConfiguredForUpdate,
     SiteConsentError,
 )
 
@@ -99,14 +100,58 @@ class SiteConsents:
                         f"Got {cdef.name}."
                     )
 
-    def get_consent_for(
-        self, subject_identifier: str, report_datetime: datetime, site_id: int
+    def get_consents(self, subject_identifier: str, site_id: int | None) -> list:
+        consents = []
+        for cdef in self.all():
+            if consent_obj := cdef.get_consent_for(
+                subject_identifier=subject_identifier,
+                site_id=site_id,
+                raise_if_not_consented=False,
+            ):
+                consents.append(consent_obj)
+        return consents
+
+    def get_consent_or_raise(
+        self,
+        subject_identifier: str,
+        report_datetime: datetime,
+        site_id: int,
+        raise_if_not_consented: bool | None = None,
     ):
+        """Returns a subject consent using this consent_definition's
+        `model_cls` and `version`.
+
+        If it does not exist and this consent_definition updates a
+        previous (`update_cdef`), will try again with the `update_cdef's`
+        model_cls and version.
+
+        Finally, if the subject consent does not exist raises a
+        `NotConsentedError`.
+        """
         from edc_sites.site import sites as site_sites  # avoid circular import
 
+        raise_if_not_consented = (
+            True if raise_if_not_consented is None else raise_if_not_consented
+        )
         single_site = site_sites.get(site_id)
         cdef = self.get_consent_definition(report_datetime=report_datetime, site=single_site)
-        return cdef.get_consent_for(subject_identifier)
+        consent_obj = cdef.get_consent_for(
+            subject_identifier, raise_if_not_consented=raise_if_not_consented
+        )
+        if consent_obj and report_datetime < consent_obj.consent_datetime:
+            if not cdef.updates:
+                dte = formatted_date(report_datetime)
+                raise ConsentDefinitionNotConfiguredForUpdate(
+                    f"Consent not configured to update any previous versions. "
+                    f"Got '{cdef.version}'. "
+                    f"Has subject '{subject_identifier}' completed version '{cdef.version}' "
+                    f"of consent on or after report_datetime='{dte}'?"
+                )
+            else:
+                return cdef.updates.get_consent_for(
+                    subject_identifier, raise_if_not_consented=raise_if_not_consented
+                )
+        return consent_obj
 
     def get_consent_definition(
         self,

--- a/edc_consent/site_consents.py
+++ b/edc_consent/site_consents.py
@@ -47,6 +47,9 @@ class SiteConsents:
         self.registry.update({cdef.name: cdef})
         self.loaded = True
 
+    def unregister(self, cdef: ConsentDefinition) -> None:
+        self.registry.pop(cdef.name, None)
+
     def get_registry_display(self):
         cdefs = sorted(list(self.registry.values()), key=lambda x: x.version)
         return "', '".join([cdef.display_name for cdef in cdefs])

--- a/edc_consent/tests/test_settings.py
+++ b/edc_consent/tests/test_settings.py
@@ -19,6 +19,7 @@ project_settings = DefaultTestSettings(
         "sites.E101",
         "edc_navbar.E002",
         "edc_navbar.E003",
+        "edc_sites.E001",
     ],
     ETC_DIR=str(base_dir / app_name / "tests" / "etc"),
     EDC_NAVBAR_DEFAULT="edc_consent",

--- a/edc_consent/tests/tests/test_consent_form.py
+++ b/edc_consent/tests/tests/test_consent_form.py
@@ -55,23 +55,23 @@ class TestConsentForm(TestCase):
         self.study_close_datetime = ResearchProtocolConfig().study_close_datetime
 
         self.consent_v1 = self.consent_factory(
+            proxy_model="consent_app.subjectconsentv1",
             start=self.study_open_datetime,
             end=self.study_open_datetime + timedelta(days=50),
-            model="consent_app.subjectconsentv1",
             version="1.0",
         )
 
         self.consent_v2 = self.consent_factory(
+            proxy_model="consent_app.subjectconsentv2",
             start=self.study_open_datetime + timedelta(days=51),
             end=self.study_open_datetime + timedelta(days=100),
-            model="consent_app.subjectconsentv2",
             version="2.0",
         )
         self.consent_v3 = self.consent_factory(
+            proxy_model="consent_app.subjectconsentv3",
             start=self.study_open_datetime + timedelta(days=101),
             end=self.study_open_datetime + timedelta(days=150),
             version="3.0",
-            model="consent_app.subjectconsentv3",
             updates=self.consent_v2,
         )
         site_consents.register(self.consent_v1)
@@ -92,8 +92,8 @@ class TestConsentForm(TestCase):
             age_max=kwargs.get("age_max", 64),
             age_is_adult=kwargs.get("age_is_adult", 18),
         )
-        model = kwargs.get("model", "consent_app.subjectconsentv1")
-        consent_definition = ConsentDefinition(model, **options)
+        proxy_model = kwargs.get("proxy_model", "consent_app.subjectconsentv1")
+        consent_definition = ConsentDefinition(proxy_model, **options)
         return consent_definition
 
     def cleaned_data(self, **kwargs):

--- a/edc_consent/tests/tests/test_consent_model.py
+++ b/edc_consent/tests/tests/test_consent_model.py
@@ -6,13 +6,12 @@ from dateutil.relativedelta import relativedelta
 from django.contrib.sites.models import Site
 from django.test import TestCase, override_settings, tag
 from edc_protocol.research_protocol_config import ResearchProtocolConfig
-from edc_sites.site import sites as site_sites
 from edc_utils import get_utcnow
 from edc_visit_schedule.site_visit_schedules import site_visit_schedules
 from faker import Faker
 from model_bakery import baker
 
-from consent_app.models import CrfOne, SubjectVisit
+from consent_app.models import CrfOne, SubjectConsent, SubjectVisit
 from consent_app.visit_schedules import get_visit_schedule
 from edc_consent.field_mixins import IdentityFieldsMixinError
 from edc_consent.site_consents import site_consents
@@ -51,6 +50,8 @@ class TestConsentModel(TestCase):
             end=self.study_open_datetime + timedelta(days=100),
             version="2.0",
         )
+
+        self.consent_v3_start_date = self.study_open_datetime + timedelta(days=101)
         self.consent_v3 = consent_factory(
             proxy_model="consent_app.subjectconsentv3",
             start=self.study_open_datetime + timedelta(days=101),
@@ -63,6 +64,7 @@ class TestConsentModel(TestCase):
         site_consents.register(self.consent_v3)
         self.dob = self.study_open_datetime - relativedelta(years=25)
 
+    @tag("1")
     def test_encryption(self):
         subject_consent = baker.make_recipe(
             "consent_app.subjectconsentv1",
@@ -72,6 +74,7 @@ class TestConsentModel(TestCase):
         )
         self.assertEqual(subject_consent.first_name, "ERIK")
 
+    @tag("1")
     def test_gets_subject_identifier(self):
         """Asserts a blank subject identifier is set to the
         subject_identifier_as_pk.
@@ -89,6 +92,7 @@ class TestConsentModel(TestCase):
         self.assertIsNotNone(consent.subject_identifier)
         self.assertNotEqual(consent.subject_identifier, consent.subject_identifier_as_pk)
 
+    @tag("1")
     def test_subject_has_current_consent(self):
         subject_identifier = "123456789"
         identity = "987654321"
@@ -125,7 +129,12 @@ class TestConsentModel(TestCase):
         )
         self.assertEqual(subject_consent.version, "2.0")
 
-    def test_model_updates(self):
+    @tag("1")
+    def test_model_updates_version_according_to_cdef_used(self):
+        """Asserts the consent model finds the cdef and updates
+        column `version` using to the version number on the
+        cdef.
+        """
         subject_identifier = "123456789"
         identity = "987654321"
         consent = baker.make_recipe(
@@ -156,11 +165,19 @@ class TestConsentModel(TestCase):
         )
         self.assertEqual(consent.version, "3.0")
 
-    def test_model_updates2(self):
+    @tag("1")
+    def test_model_updates_version_according_to_cdef_used2(self):
+        """Asserts the consent model finds the `cdef` and updates
+        column `version` using to the version number on the
+        `cdef`.
+
+        Note: we get the `model_cls` by looking up the `cdef` first.
+        """
         subject_identifier = "123456789"
         identity = "987654321"
+        cdef = site_consents.get_consent_definition(report_datetime=self.study_open_datetime)
         consent = baker.make_recipe(
-            "consent_app.subjectconsentv1",
+            cdef.model,
             subject_identifier=subject_identifier,
             identity=identity,
             confirm_identity=identity,
@@ -168,8 +185,9 @@ class TestConsentModel(TestCase):
             dob=get_utcnow() - relativedelta(years=25),
         )
         self.assertEqual(consent.version, "1.0")
+        cdef = site_consents.get_consent_definition(report_datetime=self.study_open_datetime)
         consent = baker.make_recipe(
-            "consent_app.subjectconsentv3",
+            cdef.model,
             subject_identifier=subject_identifier,
             identity=identity,
             confirm_identity=identity,
@@ -178,7 +196,11 @@ class TestConsentModel(TestCase):
         )
         self.assertEqual(consent.version, "3.0")
 
-    def test_model_updates_or_first_based_on_date(self):
+    def test_model_correctly_gets_v3_by_date(self):
+        """Asserts that a consent model instance created when the
+        current date is within the V3 validity period correctly
+        has `instance.version == 3.0`.
+        """
         traveller = time_machine.travel(self.study_open_datetime + timedelta(days=110))
         traveller.start()
         subject_identifier = "123456789"
@@ -194,11 +216,19 @@ class TestConsentModel(TestCase):
         self.assertEqual(consent.version, "3.0")
 
     def test_model_updates_from_v1_to_v2(self):
-        traveller = time_machine.travel(self.study_open_datetime)
-        traveller.start()
+        """Assert, for a single participant, a second consent model
+        instance submitted within the v2 validity period has
+        version == 2.0.
+
+        Also note that there are now 2 instances of the consent
+        model for this participant.
+        """
         subject_identifier = "123456789"
         identity = "987654321"
 
+        # travel to V1 validity period
+        traveller = time_machine.travel(self.study_open_datetime)
+        traveller.start()
         cdef = site_consents.get_consent_definition(report_datetime=get_utcnow())
         subject_consent = baker.make_recipe(
             cdef.model,
@@ -208,15 +238,18 @@ class TestConsentModel(TestCase):
             consent_datetime=get_utcnow(),
             dob=get_utcnow() - relativedelta(years=25),
         )
+        self.assertEqual(subject_consent.version, "2.0")
         self.assertEqual(subject_consent.subject_identifier, subject_identifier)
         self.assertEqual(subject_consent.identity, identity)
         self.assertEqual(subject_consent.confirm_identity, identity)
         self.assertEqual(subject_consent.version, cdef.version)
         self.assertEqual(subject_consent.consent_definition_name, cdef.name)
         traveller.stop()
+
+        # travel to V2 validity period
+        # create second consent for the same individual
         traveller = time_machine.travel(self.study_open_datetime + timedelta(days=51))
         traveller.start()
-
         cdef = site_consents.get_consent_definition(report_datetime=get_utcnow())
         subject_consent = cdef.model_cls(
             subject_identifier=subject_identifier,
@@ -227,80 +260,13 @@ class TestConsentModel(TestCase):
         )
         subject_consent.save()
         subject_consent.refresh_from_db()
+        self.assertEqual(subject_consent.version, "2.0")
         self.assertEqual(subject_consent.subject_identifier, subject_identifier)
         self.assertEqual(subject_consent.identity, identity)
         self.assertEqual(subject_consent.confirm_identity, identity)
         self.assertEqual(subject_consent.consent_definition_name, cdef.name)
 
-    def test_v3_extends_v2_end_date_up_to_v3_consent_datetime(self):
-        # TODO: is this a valid test? How does it fill in data from
-        #  the previous consent?
-        traveller = time_machine.travel(self.study_open_datetime)
-        traveller.start()
-        subject_identifier = "123456789"
-        identity = "987654321"
-
-        # consent version 1
-        cdef = site_consents.get_consent_definition(report_datetime=get_utcnow())
-        subject_consent = baker.make_recipe(
-            cdef.model,
-            subject_identifier=subject_identifier,
-            identity=identity,
-            confirm_identity=identity,
-            consent_datetime=get_utcnow(),
-            dob=get_utcnow() - relativedelta(years=25),
-        )
-        self.assertEqual(subject_consent.consent_definition_name, cdef.name)
-        self.assertEqual(subject_consent.version, "1.0")
-        traveller.stop()
-
-        # consent version 2
-        traveller = time_machine.travel(self.study_open_datetime + timedelta(days=51))
-        traveller.start()
-        cdef = site_consents.get_consent_definition(report_datetime=get_utcnow())
-        subject_consent = baker.make_recipe(
-            cdef.model,
-            subject_identifier=subject_identifier,
-            consent_datetime=get_utcnow(),
-            dob=get_utcnow() - relativedelta(years=25),
-        )
-        self.assertEqual(subject_consent.consent_definition_name, cdef.name)
-        self.assertEqual(subject_consent.version, "2.0")
-        traveller.stop()
-
-        # consent version 3.0
-        traveller = time_machine.travel(cdef.end + relativedelta(days=5))
-        traveller.start()
-        cdef = site_consents.get_consent_definition(report_datetime=get_utcnow())
-        subject_consent = baker.make_recipe(
-            cdef.model,
-            subject_identifier=subject_identifier,
-            consent_datetime=get_utcnow(),
-            dob=get_utcnow() - relativedelta(years=25),
-        )
-        self.assertEqual(subject_consent.consent_definition_name, cdef.name)
-        self.assertEqual(subject_consent.version, "3.0")
-        self.assertEqual(cdef.version, "3.0")
-
-        # get cdef for 3.0
-        cdef = site_consents.get_consent_definition(
-            report_datetime=get_utcnow(), site=site_sites.get(subject_consent.site.id)
-        )
-        self.assertEqual(cdef.version, "3.0")
-
-        # use cdef-3.0 to get subject_consent 3.0
-        subject_consent = cdef.get_consent_for(
-            subject_identifier=subject_identifier, report_datetime=get_utcnow()
-        )
-        self.assertEqual(subject_consent.version, "3.0")
-
-        # use cdef-3.0 to get subject_consent 2.0 showing that the lower bound
-        # of a cdef that updates is extended to return a 2.0 consent
-        subject_consent = cdef.get_consent_for(
-            subject_identifier=subject_identifier,
-            report_datetime=cdef.start - relativedelta(days=1),
-        )
-        self.assertEqual(subject_consent.version, "2.0")
+        self.assertEqual(SubjectConsent.objects.filter(identity, identity).count(), 2)
 
     def test_first_consent_is_v2(self):
         traveller = time_machine.travel(self.study_open_datetime + timedelta(days=51))
@@ -619,9 +585,15 @@ class TestConsentModel(TestCase):
                 subject_identifier=subject_identifier,
                 report_datetime=datetime_within_consent_v3,
             )
+        except NotConsentedError:
+            self.fail("NotConsentedError unexpectedly raised")
+        try:
             crf_one.save()
         except NotConsentedError:
             self.fail("NotConsentedError unexpectedly raised")
+
+        crf_one.report_datetime = get_utcnow()
+        crf_one.save()
 
         # now try to save CRF at within v4 period
         self.assertRaises(

--- a/edc_consent/tests/tests/test_validity_periods.py
+++ b/edc_consent/tests/tests/test_validity_periods.py
@@ -1,0 +1,150 @@
+from datetime import datetime, timedelta
+from zoneinfo import ZoneInfo
+
+import time_machine
+from dateutil.relativedelta import relativedelta
+from django.conf import settings
+from django.test import TestCase, override_settings, tag
+from edc_protocol.research_protocol_config import ResearchProtocolConfig
+from edc_utils import get_utcnow
+from faker import Faker
+from model_bakery import baker
+
+from consent_app.models import SubjectConsent
+from edc_consent.site_consents import site_consents
+
+from ..consent_test_utils import consent_factory
+
+fake = Faker()
+
+
+@time_machine.travel(datetime(2019, 4, 1, 8, 00, tzinfo=ZoneInfo("UTC")))
+@override_settings(
+    EDC_PROTOCOL_STUDY_OPEN_DATETIME=get_utcnow() - relativedelta(years=5),
+    EDC_PROTOCOL_STUDY_CLOSE_DATETIME=get_utcnow() + relativedelta(years=1),
+    EDC_AUTH_SKIP_SITE_AUTHS=True,
+    EDC_AUTH_SKIP_AUTH_UPDATER=False,
+)
+class TestConsentModel(TestCase):
+    def setUp(self):
+        self.study_open_datetime = ResearchProtocolConfig().study_open_datetime
+        self.study_close_datetime = ResearchProtocolConfig().study_close_datetime
+        site_consents.registry = {}
+        self.consent_v1 = consent_factory(
+            proxy_model="consent_app.subjectconsentv1",
+            start=self.study_open_datetime,
+            end=self.study_open_datetime + timedelta(days=50),
+            version="1.0",
+        )
+        self.consent_v2 = consent_factory(
+            proxy_model="consent_app.subjectconsentv2",
+            start=self.study_open_datetime + timedelta(days=51),
+            end=self.study_open_datetime + timedelta(days=100),
+            version="2.0",
+        )
+
+        self.consent_v3_start_date = self.study_open_datetime + timedelta(days=101)
+        self.consent_v3 = consent_factory(
+            proxy_model="consent_app.subjectconsentv3",
+            start=self.study_open_datetime + timedelta(days=101),
+            end=self.study_open_datetime + timedelta(days=150),
+            version="3.0",
+            updates=self.consent_v2,
+        )
+        site_consents.register(self.consent_v1)
+        site_consents.register(self.consent_v2, updated_by=self.consent_v3)
+        site_consents.register(self.consent_v3)
+        self.dob = self.study_open_datetime - relativedelta(years=25)
+
+        self.subject_identifier = "123456789"
+        self.identity = "987654321"
+
+        # travel to consent v1 validity period and consent subject
+        traveller = time_machine.travel(self.study_open_datetime)
+        traveller.start()
+        self.v1_consent_datetime = get_utcnow()
+        cdef = site_consents.get_consent_definition(report_datetime=self.v1_consent_datetime)
+        baker.make_recipe(
+            cdef.model,
+            subject_identifier=self.subject_identifier,
+            identity=self.identity,
+            confirm_identity=self.identity,
+            consent_datetime=self.v1_consent_datetime,
+            dob=get_utcnow() - relativedelta(years=25),
+        )
+        traveller.stop()
+
+        # travel to consent v2 validity period and consent subject
+        traveller = time_machine.travel(self.study_open_datetime + timedelta(days=51))
+        traveller.start()
+        self.v2_consent_datetime = get_utcnow()
+        cdef = site_consents.get_consent_definition(report_datetime=self.v2_consent_datetime)
+        baker.make_recipe(
+            cdef.model,
+            subject_identifier=self.subject_identifier,
+            identity=self.identity,
+            confirm_identity=self.identity,
+            consent_datetime=self.v2_consent_datetime,
+            dob=get_utcnow() - relativedelta(years=25),
+        )
+        traveller.stop()
+
+        # travel to consent v3 validity period and consent subject
+        # not this is 10 days into v3 validity period
+        traveller = time_machine.travel(cdef.end + relativedelta(days=10))
+        traveller.start()
+        self.v3_consent_datetime = get_utcnow()
+        cdef = site_consents.get_consent_definition(report_datetime=self.v3_consent_datetime)
+        baker.make_recipe(
+            cdef.model,
+            subject_identifier=self.subject_identifier,
+            identity=self.identity,
+            confirm_identity=self.identity,
+            consent_datetime=self.v3_consent_datetime,
+            dob=get_utcnow() - relativedelta(years=25),
+        )
+        traveller.stop()
+
+        # Note: subject now has three consents in the table.
+        self.assertEqual(SubjectConsent.objects.filter(identity=self.identity).count(), 3)
+
+    @tag("4")
+    def test_is_v2_within_v2_consent_period(self):
+        consent = site_consents.get_consent_for(
+            subject_identifier=self.subject_identifier,
+            report_datetime=self.consent_v3_start_date - relativedelta(days=5),
+            site_id=settings.SITE_ID,
+        )
+        self.assertEqual(consent.version, "2.0")
+
+    @tag("5")
+    def test_is_v2_after_v2_end_date_but_before_v3_consent_date(self):
+        """Assert returns v2 in the gap between the end of the
+        v2 consent period and the subject's v3 consent date.
+
+        v
+        """
+        consent = site_consents.get_consent_for(
+            subject_identifier=self.subject_identifier,
+            report_datetime=self.v3_consent_datetime - relativedelta(days=5),
+            site_id=settings.SITE_ID,
+        )
+        self.assertEqual(consent.version, "2.0")
+
+    @tag("4")
+    def test_is_v3_on_v3_consent_date(self):
+        consent = site_consents.get_consent_for(
+            subject_identifier=self.subject_identifier,
+            report_datetime=self.v3_consent_datetime,
+            site_id=settings.SITE_ID,
+        )
+        self.assertEqual(consent.version, "3.0")
+
+    @tag("4")
+    def test_is_v3_on_after_v3_consent_date(self):
+        consent = site_consents.get_consent_for(
+            subject_identifier=self.subject_identifier,
+            report_datetime=self.v3_consent_datetime + relativedelta(days=5),
+            site_id=settings.SITE_ID,
+        )
+        self.assertEqual(consent.version, "3.0")


### PR DESCRIPTION
- get consent model instance from site_consents.get_consent_or_raise instead of using cdef.get_consent
- check consent date after query and before returning model instance to determine version correctly where version updates a previous 
- update tests